### PR TITLE
add command exit after pkill tail

### DIFF
--- a/api-deploy.sh
+++ b/api-deploy.sh
@@ -104,7 +104,8 @@ function watch(){
 
                 if [[ "$line" == *"$whatToFind"* ]]; then
                     echo $msgAppStarted
-                    pkill  tail
+                    pkill tail
+                    exit
                 fi
         done
 }


### PR DESCRIPTION
hello, sorry for my english.
when deploy my project, log show:
`Application Started... exiting buffer!`
`Build step 'Execute shell' marked build as failure`
`Finished: FAILURE`
it means project started, but shell's $? is 1, I think should add command exit.
thanks
